### PR TITLE
Make plugin compatible with sentry-symfony v2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=7.1",
     "contao/core-bundle": "^4.4",
-    "sentry/sentry-symfony": "^2.0"
+    "sentry/sentry-symfony": "^2.1"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -33,7 +33,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, DependentP
     public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig): void
     {
         // load default config from SentryBundle
-        $loader->load('@SentryBundle/Resources/config/services.yml');
+        $loader->load('@SentryBundle/Resources/config/services.xml');
     }
 
     public function getPackageDependencies(): array


### PR DESCRIPTION
`getsentry/senty-symfony` released v2.1 recently. In that version, they moved from the `services.yml` to a `services.xml` in getsentry/sentry-symfony#155.

This change makes the ContaoManagerPlugin incompatible with that version.

### Screenshot:

<img width="1270" alt="screenshot 2018-11-06 at 14 32 12" src="https://user-images.githubusercontent.com/1284725/48067534-d226b780-e1d0-11e8-8d03-7fd609ab46dc.png">
