### PR TITLE
Allow custom dsn host

### DIFF
--- a/src/Twig/ContaoSentryTwigRuntime.php
+++ b/src/Twig/ContaoSentryTwigRuntime.php
@@ -16,9 +16,15 @@ class ContaoSentryTwigRuntime
     public function sentryDsn(): ?string
     {
         if (null !== $client = SentryBundle::getCurrentHub()->getClient()) {
-            $options = $client->getOptions();
+            $dsn = $client->getOptions()->getDsn(false);
 
-            return sprintf('https://%s@sentry.io/%s', $options->getPublicKey(), $options->getProjectId());
+            return sprintf(
+                '%s://%s@%s/%s',
+                $dsn->getScheme(),
+                $dsn->getPublicKey(),
+                $dsn->getHost(),
+                $dsn->getProjectId()
+            );
         }
 
         return null;


### PR DESCRIPTION
This removes some deprecations (accessing $options->getPojrectId() is deprecated) and allows to run Sentry in a self-hosted environment (if host differs from "sentry.io").