### PR TITLE
Allow sentry-symfony version 5 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
   "require": {
     "php": "^7.1 || ^8.0",
     "contao/core-bundle": "^4.4 || ^5.0",
-    "sentry/sentry-symfony": "^4.0",
+    "sentry/sentry-symfony": "^4.0 || ^5.0",
     "twig/twig": "^2.7 || ^3.0"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0",
     "friendsofphp/php-cs-fixer": "^2.13",
     "phpstan/phpstan": "^1.10",
-    "sentry/sentry": "^3.0",
+    "sentry/sentry": "^3.0 || ^4.0",
     "symfony/config": "^4.0 || ^5.0 || ^6.0",
     "symfony/dependency-injection": "^4.0 || ^5.0 || ^6.0",
     "symfony/http-kernel": "^4.0 || ^5.0 || ^6.0"


### PR DESCRIPTION
Closes #10 