### PR TITLE
Include default configuration for Contao managed edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Contao Sentry Bundle
 ====================
 
-This Contao bundle provides an easy integration of [sentry.io](https://sentry.io/) for Contao 4.4.x and newer.
+This Contao bundle provides an easy integration of [sentry.io](https://sentry.io/) for Contao 4.13 and 5.x.
 
 [![Author](http://img.shields.io/badge/author-@1upgmbh-blue.svg?style=flat-square)](https://twitter.com/1upgmbh)
 [![Software License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
@@ -9,7 +9,7 @@ This Contao bundle provides an easy integration of [sentry.io](https://sentry.io
 
 --
 
-In the first place, this is an "wrapper extension" for the [`sentry/sentry-symfony` bundle][1]. Therefore, you need to
+In the first place, this is a "wrapper extension" for the [`sentry/sentry-symfony` bundle][1]. Therefore, you need to
 configure this bundle as you would configure the `sentry/sentry-symfony` bundle: [Documentation][2]
 
 ### Recommended configuration
@@ -44,7 +44,7 @@ some comments.
 
 In order to integrate this feature, you have to alter the error page template. Place a copy of 
 `vendor/contao/core-bundle/src/Resources/views/Error/layout.html.twig` in the directory 
-`app/Resources/ContaoCoreBundle/views/Error/`.
+`templates/ContaoCoreBundle/views/Error/`.
 
 Modify the copied template and place the following snippet just before the closing `</body>` tag:
 ```twig

--- a/README.md
+++ b/README.md
@@ -9,32 +9,26 @@ This Contao bundle provides an easy integration of [sentry.io](https://sentry.io
 
 --
 
-In the first place, this is a "wrapper extension" for the [`sentry/sentry-symfony` bundle][1]. Therefore, you need to
-configure this bundle as you would configure the `sentry/sentry-symfony` bundle: [Documentation][2]
+This is a "wrapper extension" for the [`sentry/sentry-symfony` bundle][1].
 
-### Recommended configuration
 
-If you also want to report the system log errors to Sentry, this is the recommended configuration:
+### Setup in the Contao Managed Edition
 
-```yml
-sentry:
-  dsn: "https://xyz@sentry.io/xy"
-  register_error_listener: false
-  
-Sentry\Monolog\Handler:
-    arguments:
-        $hub: '@Sentry\State\HubInterface'
-        $level: !php/const Monolog\Logger::ERROR # Can be one of https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels, but System::log() only uses INFO or ERROR
-        $bubble: false
+The basic integration is automatically configured to some sane defaults. To enable
+the integration, configure the `SENTRY_DSN` variable in your `.env.local` file.
 
-monolog:
-  handlers:
-    sentry:
-      type: service
-      id: Sentry\Monolog\Handler
-      priority: 100 # Higher priority than ContaoTableHandler which will stop handling afterwards (bubbling is set to true)
-      bubble: false # Use bubble: true if you don't want the logs to show up in the system log (bubbling means, no monolog handlers will run afterwards)
-```
+Additionally, you can name the `SENTRY_ENV` in your `.env.local` file, which can be useful
+if you e.g. have a `test` and `prod` installation.
+
+If you need to change any of the defaults, simply configure 
+the `sentry/sentry-symfony` bundle according to the [Documentation][2].
+
+
+### Manual configuration
+
+If you do not use the Contao Managed Edition, you need to configure this bundle as you would 
+configure the `sentry/sentry-symfony` bundle: [Documentation][2]
+
 
 ### User feedback
 
@@ -70,6 +64,6 @@ Modify the copied template and place the following snippet just before the closi
 
 
 [1]: https://github.com/getsentry/sentry-symfony/
-[2]: https://github.com/getsentry/sentry-symfony/#configuration-of-the-sdk
+[2]: https://docs.sentry.io/platforms/php/guides/symfony/#install
 [3]: https://docs.sentry.io/learn/user-feedback/
 [4]: https://user-images.githubusercontent.com/1284725/41782120-a06637f0-7639-11e8-96d7-a053e7ddd232.png

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
-    "contao/core-bundle": "^4.4 || ^5.0",
-    "sentry/sentry-symfony": "^4.0 || ^5.0",
+    "php": "^8.1",
+    "contao/core-bundle": "^4.13 || ^5.0",
+    "sentry/sentry-symfony": "^5.0",
     "twig/twig": "^2.7 || ^3.0"
   },
   "require-dev": {
@@ -43,11 +43,11 @@
     }
   },
   "extra": {
-    "contao-manager-plugin": "Oneup\\Contao\\SentryBundle\\ContaoManager\\Plugin"
+    "contao-manager-plugin": "Oneup\\ContaoSentryBundle\\ContaoManager\\Plugin"
   },
   "autoload": {
     "psr-4": {
-      "Oneup\\Contao\\SentryBundle\\": "src"
+      "Oneup\\ContaoSentryBundle\\": "src"
     }
   },
   "support": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,11 +1,14 @@
 services:
-    Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigExtension:
+    oneup_contao_sentry.twig.extension:
+        class: Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigExtension
         tags:
             - { name: twig.extension }
 
-    Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigRuntime:
+    oneup_contao_sentry.twig.runtime:
+        class: Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigRuntime
         public: false
         tags:
             - { name: twig.runtime }
 
-    Oneup\ContaoSentryBundle\Integration\IgnorePreviousExceptionsIntegration: ~
+    oneup_contao_sentry.integration.ignore_previous_exceptions:
+        class: Oneup\ContaoSentryBundle\Integration\IgnorePreviousExceptionsIntegration

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,3 +7,5 @@ services:
         public: false
         tags:
             - { name: twig.runtime }
+
+    Oneup\ContaoSentryBundle\Integration\IgnorePreviousExceptionsIntegration: ~

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,9 +1,9 @@
 services:
-    Oneup\Contao\SentryBundle\Twig\ContaoSentryTwigExtension:
+    Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigExtension:
         tags:
             - { name: twig.extension }
 
-    Oneup\Contao\SentryBundle\Twig\ContaoSentryTwigRuntime:
+    Oneup\ContaoSentryBundle\Twig\ContaoSentryTwigRuntime:
         public: false
         tags:
             - { name: twig.runtime }

--- a/config/skeleton.yaml
+++ b/config/skeleton.yaml
@@ -1,6 +1,6 @@
 parameters:
-    '%env(SENTRY_DSN)%': ''
-    '%env(SENTRY_ENV)%': '%kernel.environment%'
+    env(SENTRY_DSN): ''
+    env(SENTRY_ENV): '%kernel.environment%'
 
 sentry:
     dsn: '%env(SENTRY_DSN)%'

--- a/config/skeleton.yaml
+++ b/config/skeleton.yaml
@@ -1,0 +1,39 @@
+parameters:
+    '%env(SENTRY_DSN)%': ''
+    '%env(SENTRY_ENV)%': '%kernel.environment%'
+
+sentry:
+    dsn: '%env(SENTRY_DSN)%'
+    register_error_listener: false
+    register_error_handler: false
+    options:
+        environment: "%env(SENTRY_ENV)%"
+        before_send: Oneup\ContaoSentryBundle\Integration\IgnorePreviousExceptionsIntegration
+        ignore_exceptions:
+            - Contao\CoreBundle\Exception\AccessDeniedException
+            - Contao\CoreBundle\Exception\AjaxRedirectResponseException
+            - Contao\CoreBundle\Exception\InsufficientAuthenticationException
+            - Contao\CoreBundle\Exception\InvalidRequestTokenException
+            - Contao\CoreBundle\Exception\NoActivePageFoundException
+            - Contao\CoreBundle\Exception\NoContentResponseException
+            - Contao\CoreBundle\Exception\PageNotFoundException
+            - Contao\CoreBundle\Exception\RedirectResponseException
+            - Contao\CoreBundle\Exception\ResponseException
+            - Contao\CoreBundle\Exception\ServiceUnavailableException
+            - Contao\UnusedArgumentsException
+            - Symfony\Component\Console\Exception\CommandNotFoundException
+            - Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+            - Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
+            - Symfony\Component\Security\Core\Exception\AccessDeniedException
+
+monolog:
+    handlers:
+        sentry:
+            type: sentry
+            level: !php/const Monolog\Logger::ERROR
+            hub_id: Sentry\State\HubInterface
+
+services:
+    Monolog\Processor\PsrLogMessageProcessor:
+        tags: { name: monolog.processor, handler: sentry }

--- a/config/skeleton.yaml
+++ b/config/skeleton.yaml
@@ -8,7 +8,7 @@ sentry:
     register_error_handler: false
     options:
         environment: "%env(SENTRY_ENV)%"
-        before_send: Oneup\ContaoSentryBundle\Integration\IgnorePreviousExceptionsIntegration
+        before_send: oneup_contao_sentry.integration.ignore_previous_exceptions
         ignore_exceptions:
             - Contao\CoreBundle\Exception\AccessDeniedException
             - Contao\CoreBundle\Exception\AjaxRedirectResponseException

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -2,36 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Oneup\Contao\SentryBundle\ContaoManager;
+namespace Oneup\ContaoSentryBundle\ContaoManager;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
-use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
-use Oneup\Contao\SentryBundle\OneupContaoSentryBundle;
+use Oneup\ContaoSentryBundle\OneupContaoSentryBundle;
 use Sentry\SentryBundle\SentryBundle;
 
-class Plugin implements BundlePluginInterface, DependentPluginInterface
+class Plugin implements BundlePluginInterface
 {
     public function getBundles(ParserInterface $parser): array
     {
         return [
-            // load SentryBundle (dependency)
-            BundleConfig::create(SentryBundle::class)->setLoadAfter([ContaoCoreBundle::class]),
-
-            // load OneupContaoSentryBundle
+            BundleConfig::create(SentryBundle::class),
             BundleConfig::create(OneupContaoSentryBundle::class)->setLoadAfter([
                 ContaoCoreBundle::class,
                 SentryBundle::class,
             ]),
-        ];
-    }
-
-    public function getPackageDependencies(): array
-    {
-        return [
-            'sentry/sentry-symfony',
         ];
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -8,10 +8,12 @@ use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Oneup\ContaoSentryBundle\OneupContaoSentryBundle;
 use Sentry\SentryBundle\SentryBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
 
-class Plugin implements BundlePluginInterface
+class Plugin implements BundlePluginInterface, ConfigPluginInterface
 {
     public function getBundles(ParserInterface $parser): array
     {
@@ -22,5 +24,10 @@ class Plugin implements BundlePluginInterface
                 SentryBundle::class,
             ]),
         ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig): void
+    {
+        $loader->load(__DIR__.'/../../config/skeleton.yaml');
     }
 }

--- a/src/DependencyInjection/OneupContaoSentryExtension.php
+++ b/src/DependencyInjection/OneupContaoSentryExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\Contao\SentryBundle\DependencyInjection;
+namespace Oneup\ContaoSentryBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,7 +18,7 @@ class OneupContaoSentryExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.yml');
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../config'));
+        $loader->load('services.yaml');
     }
 }

--- a/src/Integration/IgnorePreviousExceptionsIntegration.php
+++ b/src/Integration/IgnorePreviousExceptionsIntegration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneup\ContaoSentryBundle\Integration;
+
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\SentrySdk;
+
+class IgnorePreviousExceptionsIntegration
+{
+    public function __invoke(Event $event, ?EventHint $hint): ?Event
+    {
+        if (!($exception = $hint?->exception) instanceof \Throwable) {
+            return $event;
+        }
+
+        $sentry = SentrySdk::getCurrentHub();
+
+        foreach ($sentry->getClient()?->getOptions()->getIgnoreExceptions() ?? [] as $class) {
+            while ($exception && $exception = $exception->getPrevious()) {
+                if (\is_a($exception, $class)) {
+                    return null;
+                }
+            }
+        }
+
+        return $event;
+    }
+}

--- a/src/OneupContaoSentryBundle.php
+++ b/src/OneupContaoSentryBundle.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Oneup\Contao\SentryBundle;
+namespace Oneup\ContaoSentryBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class OneupContaoSentryBundle extends Bundle
 {
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
 }

--- a/src/Twig/ContaoSentryTwigExtension.php
+++ b/src/Twig/ContaoSentryTwigExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\Contao\SentryBundle\Twig;
+namespace Oneup\ContaoSentryBundle\Twig;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Twig/ContaoSentryTwigRuntime.php
+++ b/src/Twig/ContaoSentryTwigRuntime.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\Contao\SentryBundle\Twig;
+namespace Oneup\ContaoSentryBundle\Twig;
 
 use Sentry\SentrySdk;
 
@@ -22,15 +22,9 @@ class ContaoSentryTwigRuntime
     public function sentryDsn(): ?string
     {
         if ((null !== $client = SentrySdk::getCurrentHub()->getClient())
-            && (null !== $dsn = $client->getOptions()->getDsn())) {
-
-            return sprintf(
-                '%s://%s@%s/%s',
-                $dsn->getScheme(),
-                $dsn->getPublicKey(),
-                $dsn->getHost(),
-                $dsn->getProjectId()
-            );
+            && (null !== $dsn = $client->getOptions()->getDsn())
+        ) {
+            return (string) $dsn;
         }
 
         return null;


### PR DESCRIPTION
This PR adds some default configurations if the bundle is included in a Contao Managed Edition. Because most times, the configuration will be identical and repetitive.

I also added an event listener to filter previous exceptions. In my case, I had Twig components throwing an `AccessDeniedException` (which correctly triggers the firewall), which are logged as `RuntimeError` even though the previous exception was one to be filtered.

The namespace also changed from `Oneup\Contao\SentryBundle` to `Oneup\ContaoSentryBundle` which I think would be more correct in terms of Composer packages.

@fritzmg @richardhj any opinions on this?

**TODO**:
 - [x] Update README