### PR TITLE
Added error handling trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you do not use the Contao Managed Edition, you need to configure this bundle 
 configure the `sentry/sentry-symfony` bundle: [Documentation][2]
 
 
-### User feedback
+## User feedback
 
 On the other hand you might want to implement the [User feedback][3] feature of sentry. The user feedback is primarily
 useful to let the users know that you've gotten notified about the issue and to let users give the opportunity to add
@@ -63,7 +63,24 @@ Modify the copied template and place the following snippet just before the closi
 ![User Feedback in action][4]
 
 
+## Error tracking helper
+
+The `Oneup\ContaoSentryBundle\ErrorHandlingTrait` adds useful Sentry helpers.
+
+- `ErrorHandlingTrait::sentryOrThrow` will either log an error/exception to sentry,
+  or it will throw an exception if Sentry integration is not available (e.g. on localhost
+  or in `dev` environment). It is mostly useful when running looping cronjobs, like
+  synchronizing Contao with a remote system, so an error on syncing a record will not prevent
+  the sync loop from finishing other records.
+
+- `ErrorHandlingTraig::sentryCheckIn` has been added for the new [Sentry Cron job monitoring][5].
+  Call `sentryCheckIn()` without argument to start a check in, and subsequently with a boolean
+  `true` or `false` after the job has successfully run or failed.
+
+
+
 [1]: https://github.com/getsentry/sentry-symfony/
 [2]: https://docs.sentry.io/platforms/php/guides/symfony/#install
 [3]: https://docs.sentry.io/learn/user-feedback/
 [4]: https://user-images.githubusercontent.com/1284725/41782120-a06637f0-7639-11e8-96d7-a053e7ddd232.png
+[5]: https://docs.sentry.io/product/crons/

--- a/src/ErrorHandlingTrait.php
+++ b/src/ErrorHandlingTrait.php
@@ -31,7 +31,7 @@ trait ErrorHandlingTrait
     private function sentryCheckIn(bool $success = null): void
     {
         $checkIn = new CheckIn(
-            monitorSlug: substr(__CLASS__, strrpos(__CLASS__, '\\')+1),
+            monitorSlug: substr(__CLASS__, strrpos(__CLASS__, '\\') + 1),
             status: match($success) {
                 null => CheckInStatus::inProgress(),
                 true => CheckInStatus::ok(),

--- a/src/ErrorHandlingTrait.php
+++ b/src/ErrorHandlingTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneup\ContaoSentryBundle;
+
+use Sentry\CheckIn;
+use Sentry\CheckInStatus;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\SentrySdk;
+
+trait ErrorHandlingTrait
+{
+    private string|null $sentryCheckInId = null;
+
+    private function sentryOrThrow(string $message, \Throwable $exception = null, array $contexts = []): void
+    {
+        $event = Event::createEvent();
+        $event->setMessage($message);
+
+        foreach ($contexts as $name => $data) {
+            $event->setContext($name, $data);
+        }
+
+        if (null === SentrySdk::getCurrentHub()->captureEvent($event, EventHint::fromArray(['exception' => $exception]))) {
+            throw new \RuntimeException($message, 0, $exception);
+        }
+    }
+
+    private function sentryCheckIn(bool $success = null): void
+    {
+        $checkIn = new CheckIn(
+            monitorSlug: substr(__CLASS__, strrpos(__CLASS__, '\\')+1),
+            status: match($success) {
+                null => CheckInStatus::inProgress(),
+                true => CheckInStatus::ok(),
+                false => CheckInStatus::error(),
+            },
+            id: $this->sentryCheckInId,
+        );
+
+        if (null === $this->sentryCheckInId) {
+            $this->sentryCheckInId = $checkIn->getId();
+        }
+
+        $event = Event::createCheckIn();
+        $event->setCheckIn($checkIn);
+
+        SentrySdk::getCurrentHub()->captureEvent($event);
+    }
+}


### PR DESCRIPTION
I used this trait for several years now in various projects. It allows to handle sentry errors without breaking code, e.g. in cronjobs that do multiple things. If Sentry integration is not active (e.g. locally), the exception is thrown as usual.

The second method is used for Sentry Cronjobs. Not sure anyone really needs that since they are now a paid feature.